### PR TITLE
Fix link to 800-53 mapping r4

### DIFF
--- a/docs/mapping_methodology.md
+++ b/docs/mapping_methodology.md
@@ -54,7 +54,7 @@ To continue with the example, further review and analysis confirms the identifie
 
 ## Applying the Methodology
 
-This methodology is designed to be tailored as it is applied to security control frameworks. We anticipate that each framework will require its own unique mapping and scoping decisions. These framework specific decisions should be documented in the ReadMe for the framework. As an example, see the [Mapping NIST 800-53 revision 4 to ATT&CK](/frameworks/nist800-53-r4#mapping-nist-800-53-revision-4-to-attck) section of the NIST 800-53 Rev. 4 mapping documentation. 
+This methodology is designed to be tailored as it is applied to security control frameworks. We anticipate that each framework will require its own unique mapping and scoping decisions. These framework specific decisions should be documented in the ReadMe for the framework. As an example, see the [Mapping NIST 800-53 revision 4 to ATT&CK](/frameworks/ATT%26CK-v8.2/nist800-53-r4#mapping-nist-800-53-revision-4-to-attck) section of the NIST 800-53 Rev. 4 mapping documentation. 
 
 ## References
 


### PR DESCRIPTION
added missing subdirectory causing 404 error when visiting the link to the "Mapping NIST 800-53 revision 4 to ATT&CK" document.

<!--  PULL REQUEST PROCESS                                                 -->
<!--  1. fill in the below sections to the best of your ability            -->
<!--  2. Assign and/or mention a reviewer (typically @isaisabel)           -->
<!--  3. Pull requests should target the develop branch                    -->
<!--  4. Make sure to update CHANGELOG.md to reflect what has changed.     -->

## Description of what has changed
<!--  Add a short description of what changed                              -->
<!--                                                                       -->
<!--  For example, "improved parser x to track y field"                    -->

## Issues addressed by pull request
<!--  If relevant, add list of issues addressed by the pull request        -->
<!--  If no issues are relevant, omit this section                         -->
<!--  Prefix issue list with keywords such as "closes",                    --> 
<!--  "resolves", or "fixes" to automatically close the                    -->
<!--  issue s when the request is merged.                                  -->
<!--                                                                       -->
<!--  For example, "Closes #24. See also #25, #26"                         -->