### PR TITLE
Fix #82 - Broken Layer Links

### DIFF
--- a/src/mappings_to_heatmaps.py
+++ b/src/mappings_to_heatmaps.py
@@ -255,7 +255,6 @@ def get_x_mitre(objects, object_type="course-of-action"):
 
 def main(framework, attack, controls, mappings, domain, version, output, clear, build_dir):
     underscore_version = version.replace('v', '').replace('.', '_')
-    dashed_framework = framework.replace('_', '-')
 
     print("loading ATT&CK data... ", end="", flush=True)
     with open(attack, "r") as f:


### PR DESCRIPTION
What Changed:
1. Fixed the build script to use correct URLs for layer files and regenerated layer files and markdown files
2. Fixes #82 and #83

Limitations:
1. Did not address other improvements in the area in order to be surgical with this change